### PR TITLE
refactor: link source games via direct columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,13 +34,12 @@ Populate source tables using their own commands (run queue workers as needed):
   - Or start scrape:        php artisan games:scrape-wikipedia --seed-high-value
 
 Schema Overview (created by this package)
-- `ga_games` (id, name, release_year, timestamps)
+- `ga_games` (id, name, release_year, gog_game_id, steam_app_id, wikipedia_game_id, timestamps)
 - `ga_companies` (id, name unique, timestamps)
 - `ga_game_developers` (pivot ga_game_id <-> ga_company_id)
 - `ga_game_publishers` (pivot ga_game_id <-> ga_company_id)
-- `ga_gog_game_links` (ga_game_id <-> gog_games.id, unique per GOG game)
-- `ga_steam_app_links` (ga_game_id <-> steam_apps.id, unique per Steam app)
-- `ga_wikipedia_game_links` (ga_game_id <-> wikipedia_games.id, unique per Wikipedia game)
+- `ga_game_categories` (pivot ga_game_id <-> ga_category_id)
+- `ga_game_genres` (pivot ga_game_id <-> ga_genre_id)
 
 Aggregation Rules
 Only source rows that meet all required fields are considered:
@@ -54,7 +53,7 @@ Matching logic for linking to `ga_games`:
   - Any developer overlaps
   - Any publisher overlaps
 
-If no aggregated record matches, a new `ga_games` row is created, missing GA companies are created, and developer/publisher relations are attached. Each source row is then linked to exactly one `ga_games` record via its link table.
+If no aggregated record matches, a new `ga_games` row is created, missing GA companies are created, and developer/publisher relations are attached. Each source row is then linked to exactly one `ga_games` record via dedicated foreign key columns.
 
 Usage
 - Real run (queues + jobs):

--- a/database/migrations/2025_09_02_110000_move_source_links_into_ga_games.php
+++ b/database/migrations/2025_09_02_110000_move_source_links_into_ga_games.php
@@ -2,8 +2,8 @@
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
-use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
 {

--- a/database/migrations/2025_09_02_110000_move_source_links_into_ga_games.php
+++ b/database/migrations/2025_09_02_110000_move_source_links_into_ga_games.php
@@ -1,0 +1,99 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('ga_games', function (Blueprint $t) {
+            $t->unsignedBigInteger('gog_game_id')->nullable()->unique()->after('release_year');
+            $t->unsignedBigInteger('steam_app_id')->nullable()->unique()->after('gog_game_id');
+            $t->unsignedBigInteger('wikipedia_game_id')->nullable()->unique()->after('steam_app_id');
+
+            $t->foreign('gog_game_id')->references('id')->on('gog_games')->cascadeOnDelete();
+            $t->foreign('steam_app_id')->references('id')->on('steam_apps')->cascadeOnDelete();
+            $t->foreign('wikipedia_game_id')->references('id')->on('wikipedia_games')->cascadeOnDelete();
+        });
+
+        // migrate existing links
+        if (Schema::hasTable('ga_gog_game_links')) {
+            foreach (DB::table('ga_gog_game_links')->get() as $row) {
+                DB::table('ga_games')->where('id', $row->ga_game_id)->update(['gog_game_id' => $row->gog_game_id]);
+            }
+        }
+        if (Schema::hasTable('ga_steam_app_links')) {
+            foreach (DB::table('ga_steam_app_links')->get() as $row) {
+                DB::table('ga_games')->where('id', $row->ga_game_id)->update(['steam_app_id' => $row->steam_app_id]);
+            }
+        }
+        if (Schema::hasTable('ga_wikipedia_game_links')) {
+            foreach (DB::table('ga_wikipedia_game_links')->get() as $row) {
+                DB::table('ga_games')->where('id', $row->ga_game_id)->update(['wikipedia_game_id' => $row->wikipedia_game_id]);
+            }
+        }
+
+        Schema::dropIfExists('ga_gog_game_links');
+        Schema::dropIfExists('ga_steam_app_links');
+        Schema::dropIfExists('ga_wikipedia_game_links');
+    }
+
+    public function down(): void
+    {
+        Schema::create('ga_gog_game_links', function (Blueprint $t) {
+            $t->unsignedBigInteger('ga_game_id');
+            $t->unsignedBigInteger('gog_game_id');
+            $t->foreign('ga_game_id')->references('id')->on('ga_games')->cascadeOnDelete();
+            $t->foreign('gog_game_id')->references('id')->on('gog_games')->cascadeOnDelete();
+            $t->unique(['gog_game_id']);
+            $t->unique(['ga_game_id', 'gog_game_id']);
+        });
+
+        Schema::create('ga_steam_app_links', function (Blueprint $t) {
+            $t->unsignedBigInteger('ga_game_id');
+            $t->unsignedBigInteger('steam_app_id');
+            $t->foreign('ga_game_id')->references('id')->on('ga_games')->cascadeOnDelete();
+            $t->foreign('steam_app_id')->references('id')->on('steam_apps')->cascadeOnDelete();
+            $t->unique(['steam_app_id']);
+            $t->unique(['ga_game_id', 'steam_app_id']);
+        });
+
+        Schema::create('ga_wikipedia_game_links', function (Blueprint $t) {
+            $t->unsignedBigInteger('ga_game_id');
+            $t->unsignedBigInteger('wikipedia_game_id');
+            $t->foreign('ga_game_id')->references('id')->on('ga_games')->cascadeOnDelete();
+            $t->foreign('wikipedia_game_id')->references('id')->on('wikipedia_games')->cascadeOnDelete();
+            $t->unique(['wikipedia_game_id']);
+            $t->unique(['ga_game_id', 'wikipedia_game_id']);
+        });
+
+        foreach (DB::table('ga_games')->whereNotNull('gog_game_id')->get(['id', 'gog_game_id']) as $row) {
+            DB::table('ga_gog_game_links')->insert([
+                'ga_game_id' => $row->id,
+                'gog_game_id' => $row->gog_game_id,
+            ]);
+        }
+        foreach (DB::table('ga_games')->whereNotNull('steam_app_id')->get(['id', 'steam_app_id']) as $row) {
+            DB::table('ga_steam_app_links')->insert([
+                'ga_game_id' => $row->id,
+                'steam_app_id' => $row->steam_app_id,
+            ]);
+        }
+        foreach (DB::table('ga_games')->whereNotNull('wikipedia_game_id')->get(['id', 'wikipedia_game_id']) as $row) {
+            DB::table('ga_wikipedia_game_links')->insert([
+                'ga_game_id' => $row->id,
+                'wikipedia_game_id' => $row->wikipedia_game_id,
+            ]);
+        }
+
+        Schema::table('ga_games', function (Blueprint $t) {
+            $t->dropForeign(['gog_game_id']);
+            $t->dropForeign(['steam_app_id']);
+            $t->dropForeign(['wikipedia_game_id']);
+            $t->dropColumn(['gog_game_id', 'steam_app_id', 'wikipedia_game_id']);
+        });
+    }
+};

--- a/src/Console/AggregateGamesCommand.php
+++ b/src/Console/AggregateGamesCommand.php
@@ -81,7 +81,7 @@ class AggregateGamesCommand extends Command
         $this->line('GOG: scanning candidates...');
         $service = app(\Artryazanov\GamesAggregator\Services\AggregationService::class);
         $q = \Artryazanov\GogScanner\Models\Game::query()
-            ->whereRaw('NOT EXISTS (SELECT 1 FROM ga_gog_game_links l WHERE l.gog_game_id = gog_games.id)')
+            ->whereRaw('NOT EXISTS (SELECT 1 FROM ga_games g WHERE g.gog_game_id = gog_games.id)')
             ->whereNotNull('title')
             ->whereHas('developers')
             ->whereHas('publishers')
@@ -144,7 +144,7 @@ class AggregateGamesCommand extends Command
         $this->line('Steam: scanning candidates...');
         $service = app(\Artryazanov\GamesAggregator\Services\AggregationService::class);
         $q = \Artryazanov\LaravelSteamAppsDb\Models\SteamApp::query()
-            ->whereRaw('NOT EXISTS (SELECT 1 FROM ga_steam_app_links l WHERE l.steam_app_id = steam_apps.id)')
+            ->whereRaw('NOT EXISTS (SELECT 1 FROM ga_games g WHERE g.steam_app_id = steam_apps.id)')
             ->whereHas('detail', fn ($q) => $q->whereNotNull('release_date'))
             ->whereHas('developers')
             ->whereHas('publishers')
@@ -197,7 +197,7 @@ class AggregateGamesCommand extends Command
         $this->line('Wikipedia: scanning candidates...');
         $service = app(\Artryazanov\GamesAggregator\Services\AggregationService::class);
         $q = \Artryazanov\WikipediaGamesDb\Models\Game::query()
-            ->whereRaw('NOT EXISTS (SELECT 1 FROM ga_wikipedia_game_links l WHERE l.wikipedia_game_id = wikipedia_games.id)')
+            ->whereRaw('NOT EXISTS (SELECT 1 FROM ga_games g WHERE g.wikipedia_game_id = wikipedia_games.id)')
             ->where(fn ($q) => $q->whereNotNull('release_year')->orWhereNotNull('release_date'))
             ->whereHas('developers')
             ->whereHas('publishers')

--- a/src/Models/GaGame.php
+++ b/src/Models/GaGame.php
@@ -12,10 +12,16 @@ class GaGame extends Model
     protected $fillable = [
         'name',
         'release_year',
+        'gog_game_id',
+        'steam_app_id',
+        'wikipedia_game_id',
     ];
 
     protected $casts = [
         'release_year' => 'integer',
+        'gog_game_id' => 'integer',
+        'steam_app_id' => 'integer',
+        'wikipedia_game_id' => 'integer',
     ];
 
     public function developers(): BelongsToMany

--- a/tests/Feature/CommandDryRunTest.php
+++ b/tests/Feature/CommandDryRunTest.php
@@ -30,6 +30,6 @@ class CommandDryRunTest extends TestCase
             ->assertExitCode(0);
 
         $this->assertDatabaseCount('ga_games', 0);
-        $this->assertDatabaseCount('ga_steam_app_links', 0);
+        $this->assertDatabaseMissing('ga_games', ['steam_app_id' => $app->id]);
     }
 }

--- a/tests/Feature/JobsAggregationTest.php
+++ b/tests/Feature/JobsAggregationTest.php
@@ -38,8 +38,7 @@ class JobsAggregationTest extends TestCase
 
         (new AggregateGogGamesJob(chunkSize: 50))->handle(app(AggregationService::class));
 
-        $this->assertDatabaseHas('ga_games', ['name' => 'Doom', 'release_year' => 1993]);
-        $this->assertDatabaseHas('ga_gog_game_links', ['gog_game_id' => 1]);
+        $this->assertDatabaseHas('ga_games', ['name' => 'Doom', 'release_year' => 1993, 'gog_game_id' => 1]);
         // Category from gog category
         $this->assertDatabaseHas('ga_categories', ['name' => 'Action']);
         $this->assertDatabaseHas('ga_genres', ['name' => 'Shooter']);
@@ -68,8 +67,7 @@ class JobsAggregationTest extends TestCase
 
         (new AggregateSteamAppsJob(chunkSize: 50))->handle(app(AggregationService::class));
 
-        $this->assertDatabaseHas('ga_games', ['name' => 'Doom', 'release_year' => 1993]);
-        $this->assertDatabaseHas('ga_steam_app_links', ['steam_app_id' => $app->id]);
+        $this->assertDatabaseHas('ga_games', ['name' => 'Doom', 'release_year' => 1993, 'steam_app_id' => $app->id]);
         $this->assertDatabaseHas('ga_categories', ['name' => 'Single-player']);
         $this->assertDatabaseHas('ga_genres', ['name' => 'Action']);
     }
@@ -92,8 +90,7 @@ class JobsAggregationTest extends TestCase
 
         (new AggregateWikipediaGamesJob(chunkSize: 50))->handle(app(AggregationService::class));
 
-        $this->assertDatabaseHas('ga_games', ['name' => 'Doom', 'release_year' => 1993]);
-        $this->assertDatabaseHas('ga_wikipedia_game_links', ['wikipedia_game_id' => $game->id]);
+        $this->assertDatabaseHas('ga_games', ['name' => 'Doom', 'release_year' => 1993, 'wikipedia_game_id' => $game->id]);
         $this->assertDatabaseHas('ga_categories', ['name' => 'Single-player']);
         $this->assertDatabaseHas('ga_genres', ['name' => 'Action']);
     }


### PR DESCRIPTION
## Summary
- add foreign key columns to `ga_games` for GOG, Steam and Wikipedia sources
- update aggregation jobs and command to use direct one-to-one links
- remove link tables and migrate existing relations
- document new schema and adjust tests

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_68b7bb25382c83328fa400d9739a42e1